### PR TITLE
chore: remove default plugins security-analytics and ml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,8 @@ steps:
     image: docker.io/plugins/docker
     settings:
       build_args:
-        - OPENSEARCH_PLUGINS=repository-s3 ingest-attachment
+        - OPENSEARCH_PLUGINS_INSTALL=repository-s3 ingest-attachment
+        - OPENSEARCH_PLUGINS_REMOVE=opensearch-security-analytics opensearch-ml
       dockerfile: Dockerfile
       dry_run: true
       repo: owncloudops/${DRONE_REPO_NAME}
@@ -42,7 +43,8 @@ steps:
     image: docker.io/plugins/docker
     settings:
       build_args:
-        - OPENSEARCH_PLUGINS=repository-s3 ingest-attachment
+        - OPENSEARCH_PLUGINS_INSTALL=repository-s3 ingest-attachment
+        - OPENSEARCH_PLUGINS_REMOVE=opensearch-security-analytics opensearch-ml
       dockerfile: Dockerfile
       password:
         from_secret: docker_password
@@ -60,7 +62,8 @@ steps:
     image: docker.io/plugins/docker
     settings:
       build_args:
-        - OPENSEARCH_PLUGINS=repository-s3 ingest-attachment
+        - OPENSEARCH_PLUGINS_INSTALL=repository-s3 ingest-attachment
+        - OPENSEARCH_PLUGINS_REMOVE=opensearch-security-analytics opensearch-ml
       dockerfile: Dockerfile
       password:
         from_secret: quay_password

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ LABEL org.opencontainers.image.documentation="https://github.com/owncloud-ops/op
 
 ARG GOMPLATE_VERSION
 ARG CONTAINER_LIBRARY_VERSION
-ARG OPENSEARCH_PLUGINS
+ARG OPENSEARCH_PLUGINS_INSTALL
+ARG OPENSEARCH_PLUGINS_REMOVE
 
 # renovate: datasource=github-releases depName=hairyhenderson/gomplate
 ENV GOMPLATE_VERSION="${GOMPLATE_VERSION:-v3.11.5}"
@@ -31,6 +32,7 @@ RUN yum install -y wget curl && \
     chmod 750 /usr/share/opensearch/config && \
     ln -s /etc/ssl/certs/ca-bundle.trust.crt /usr/share/opensearch/config/ca-bundle.trust.crt && \
     for PLUGIN in ${OPENSEARCH_PLUGINS}; do /usr/share/opensearch/bin/opensearch-plugin install -s -b "${PLUGIN}" || exit 1; done && \
+    for PLUGIN in ${OPENSEARCH_PLUGINS_REMOVE}; do /usr/share/opensearch/bin/opensearch-plugin remove -s -p "${PLUGIN}" || exit 1; done && \
     yum clean all && \
     rm -rf /tmp/*
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ OPENSEARCH_BOOTSTRAP_MEMORY_LOCK=true
 OPENSEARCH_HTTP_PORT=9200
 OPENSEARCH_HTTP_COMPRESSION=true
 
+OPENSEARCH_DEFAULT_NUMBER_OF_REPLICAS=1
+
 OPENSEARCH_PLUGINS_SECURITY_ENABLED=false
 # If you enable securoty on a production mode cluster, transport ssl is mandatory
 # and need to be configured.
@@ -82,7 +84,9 @@ OPENSEARCH_JVM_EXTRA_OPTS=
 ## Build
 
 ```Shell
-docker build -f Dockerfile -t opensearch:latest .
+docker build -f Dockerfile -t opensearch:latest . \
+    --build-arg OPENSEARCH_PLUGINS_INSTALL="repository-s3 ingest-attachment" \
+    --build-arg OPENSEARCH_PLUGINS_REMOVE="opensearch-security-analytics opensearch-ml"
 ```
 
 ## License

--- a/overlay/etc/templates/opensearch.yml.tmpl
+++ b/overlay/etc/templates/opensearch.yml.tmpl
@@ -6,6 +6,7 @@ cluster:
     - {{ . | strings.TrimSpace }}
     {{- end }}
   {{- end }}
+  default_number_of_replicas: {{ getenv "OPENSEARCH_DEFAULT_NUMBER_OF_REPLICAS" "1" }}
   routing:
     allocation:
       disk:


### PR DESCRIPTION
These plugins do not respect the `default_number_of_replicas` and leave individual node clusters in `yellow` state by default. Although there are ways to work around this in a real deployment, it is easier to just remove them as we don't use these features anyway.